### PR TITLE
Convert weather dashboard into routed SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,55 @@
 # Panel de Control del Clima en React
 
-## Descripción del Proyecto
+## Descripción general
 
-La aplicación "Panel de Control del Clima" permite a los usuarios buscar el clima actual de cualquier ciudad del mundo. La interfaz es dinámica e incluye una opción para alternar entre un modo claro y un modo oscuro.
+Esta versión del "Panel de Control del Clima" evoluciona la práctica de la Semana 3 hacia una aplicación de página única (SPA). La interfaz permite buscar ciudades, consultar información meteorológica detallada y alternar entre temas claro y oscuro desde cualquier sección del sitio.
 
-### Características
+## Características principales
 
-* **Búsqueda de Clima**: Obtiene datos del clima en tiempo real de una API pública.
+- **Búsqueda interactiva**: Consulta el clima actual de cualquier ciudad utilizando la API pública de OpenWeatherMap.
+- **Rutas dinámicas**: Navega entre Inicio, Detalles del pronóstico (`/forecast/:city`) y Acerca de, con un layout y barra de navegación compartidos.
+- **Tema global**: El modo claro/oscuro se gestiona con un `ThemeContext`, disponible en todas las rutas.
+- **Hook personalizado**: La obtención de datos se realiza mediante el hook `useFetch`, que retorna `{ data, isLoading, error }` para simplificar el manejo de estados de red.
+- **Lazy loading**: La página "Acerca de" se carga bajo demanda para optimizar el rendimiento.
 
-* **Cambio de Tema**: Alterna entre una interfaz de modo claro y oscuro.
+## Estructura de enrutamiento
 
-* **Diseño Responsivo**: La interfaz se adapta a diferentes tamaños de pantalla, desde dispositivos móviles hasta escritorios.
-
-## Metodología de Desarrollo
-
-Este proyecto se desarrolló siguiendo las mejores prácticas de React, enfocándose en la modularidad y la gestión eficiente del estado.
-
-### 1. Estructura de Componentes
-
-La aplicación se dividió en componentes lógicos y reutilizables para mantener el código limpio y ordenado.
-
-* **`App`**: El componente principal que maneja la lógica de la aplicación y el estado global.
-
-* **`SearchBar`**: Un componente controlado para la entrada de texto y el botón de búsqueda.
-
-* **`WeatherDisplay`**: Un componente para mostrar la información del clima recibida de la API.
-
-* **`ThemeSwitcher`**: Un componente simple para la funcionalidad de cambiar el tema.
-
-### 2. Gestión de Estado y Datos
-
-* Se usó el hook **`useState`** para manejar el estado de la aplicación, como la ciudad que el usuario busca, los datos del clima y el tema.
-
-* Los datos fluyen de manera unidireccional, pasando las **`props`** desde el componente padre (`App`) a los componentes hijos para que estos puedan mostrar la información y actualizar el estado cuando sea necesario.
-
-### 3. Integración con la API
-
-* Se utilizó el hook **`useEffect`** para realizar la llamada a la API de OpenWeatherMap. Esto asegura que la solicitud de datos se ejecute como un efecto secundario cada vez que el valor de la ciudad cambia.
-
-* La **API Key** se almacenó en un archivo `.env` para mantener las credenciales seguras.
-
-## Cómo Ejecutar el Proyecto
-
-Sigue estos pasos para poner en marcha la aplicación en tu entorno local.
-
-### Requisitos Previos
-
-* Node.js instalado en tu máquina.
-
-### Pasos para la Instalación
-
-1. **Clona el repositorio** o crea un nuevo proyecto con Vite y navega a la carpeta del proyecto.
-
-2. **Instala las dependencias**:
-
-```shell
-npm install
+```text
+/
+├── (layout) AppLayout
+│   ├── /                 → Home: búsqueda y vista rápida del clima
+│   ├── /forecast/:city   → ForecastDetails: detalles extendidos para la ciudad seleccionada
+│   └── /about            → About (carga diferida)
+└── *                     → Redirección al inicio
 ```
 
-3. **Configura la API Key**: En la raíz de tu proyecto, crea un archivo llamado `.env` y añade tu clave de API de OpenWeatherMap.
+La barra de navegación y el selector de tema forman parte del `AppLayout`, que utiliza `<Outlet />` para renderizar las rutas anidadas.
 
-```shell
-VITE_API_KEY=tu_clave_de_api
-```
+## Gestión de estado y hooks
 
-4. **Ejecuta la aplicación**:
+- **ThemeContext**: expone `theme` y `toggleTheme`, permitiendo alternar el modo claro/oscuro desde cualquier página.
+- **useFetch(url)**: ejecuta la solicitud HTTP indicada, controla abortos de petición y maneja errores comunes (incluyendo mensajes personalizados para respuestas 404).
 
-```shell
-npm run dev
-```
+## Configuración y ejecución
 
-### Autor
+1. **Instalar dependencias**
+   ```bash
+   npm install
+   ```
 
-Rodrigo Machaca - Rodrigo.Machaca@jala.university
+2. **Configurar la API Key**
+   Crear un archivo `.env` en la raíz del proyecto con el siguiente contenido:
+   ```bash
+   VITE_API_KEY=tu_clave_de_api
+   ```
+
+3. **Iniciar el servidor de desarrollo**
+   ```bash
+   npm run dev
+   ```
+
+## Recursos útiles
+
+- [Documentación de React Router](https://reactrouter.com)
+- [API de OpenWeatherMap](https://openweathermap.org/current)
+- [Documentación de Vite](https://vitejs.dev)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -1611,6 +1612,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2486,6 +2496,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2552,6 +2600,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,60 +1,27 @@
-import React, { useState, useEffect } from 'react';
-import SearchBar from './components/SearchBar';
-import WeatherDisplay from './components/WeatherDisplay';
-import ThemeSwitcher from './components/ThemeSwitcher';
-import './index.css';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
+import AppLayout from './layouts/AppLayout.jsx';
+import Home from './pages/Home.jsx';
+import ForecastDetails from './pages/ForecastDetails.jsx';
 
-function App() {
-  const [city, setCity] = useState('');
-  const [weatherData, setWeatherData] = useState(null);
-  const [theme, setTheme] = useState('light');
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(false);
-  
-  const API_KEY = import.meta.env.VITE_API_KEY;
+const About = lazy(() => import('./pages/About.jsx'));
 
-  useEffect(() => {
-    if (!city) {
-      return;
-    }
-
-    const fetchWeather = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const response = await fetch(
-          `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${API_KEY}&units=metric&lang=es`
-        );
-        if (!response.ok) {
-          throw new Error('No se encontraron datos del clima para esta ciudad. Por favor, revisa el nombre.');
-        }
-        const data = await response.json();
-        setWeatherData(data);
-      } catch (err) {
-        setError(err.message);
-        setWeatherData(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchWeather();
-  }, [city, API_KEY]);
-
-  const toggleTheme = () => {
-    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
-  };
-
-  return (
-    <div className={`app-container ${theme}-theme`}>
-      <div className="app-content">
-        <ThemeSwitcher theme={theme} toggleTheme={toggleTheme} />
-        <h1 className="app-title">Panel de Control del Clima</h1>
-        <SearchBar setCity={setCity} />
-        <WeatherDisplay data={weatherData} loading={loading} error={error} />
-      </div>
-    </div>
-  );
-}
+const App = () => (
+  <Routes>
+    <Route path="/" element={<AppLayout />}>
+      <Route index element={<Home />} />
+      <Route path="forecast/:city" element={<ForecastDetails />} />
+      <Route
+        path="about"
+        element={(
+          <Suspense fallback={<div className="message">Cargando sección...</div>}>
+            <About />
+          </Suspense>
+        )}
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Route>
+  </Routes>
+);
 
 export default App;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import './SearchBar.css';
 
-const SearchBar = ({ setCity }) => {
+const SearchBar = ({ onSearch }) => {
   const [inputCity, setInputCity] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (inputCity.trim() !== '') {
-      setCity(inputCity);
+    const trimmedCity = inputCity.trim();
+    if (trimmedCity !== '') {
+      onSearch?.(trimmedCity);
     }
     setInputCity('');
   };
@@ -20,6 +21,7 @@ const SearchBar = ({ setCity }) => {
         onChange={(e) => setInputCity(e.target.value)}
         placeholder="Ej: Ciudad de México, Madrid, Buenos Aires"
         className="search-input"
+        aria-label="Buscar ciudad"
       />
       <button
         type="submit"

--- a/src/components/ThemeSwitcher.css
+++ b/src/components/ThemeSwitcher.css
@@ -1,8 +1,7 @@
 .theme-switcher {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .theme-button {
@@ -14,6 +13,7 @@
   transition: background-color 0.2s ease;
   background-color: var(--bg-card-light);
   backdrop-filter: blur(8px);
+  font-size: 1.25rem;
 }
 
 .light-theme .theme-button {

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 import './ThemeSwitcher.css';
+import { useTheme } from '../context/ThemeContext.jsx';
 
-const ThemeSwitcher = ({ theme, toggleTheme }) => (
-  <div className="theme-switcher">
-    <button
-      onClick={toggleTheme}
-      className="theme-button"
-    >
-      {theme === 'light' ? '☀️' : '🌙'}
-    </button>
-  </div>
-);
+const ThemeSwitcher = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <div className="theme-switcher">
+      <button
+        onClick={toggleTheme}
+        className="theme-button"
+        type="button"
+        aria-label="Cambiar tema"
+        title={theme === 'light' ? 'Cambiar a tema oscuro' : 'Cambiar a tema claro'}
+      >
+        {theme === 'light' ? '☀️' : '🌙'}
+      </button>
+    </div>
+  );
+};
 
 export default ThemeSwitcher;

--- a/src/components/WeatherDisplay.css
+++ b/src/components/WeatherDisplay.css
@@ -30,7 +30,6 @@
 
 .date {
   font-size: 0.875rem;
-  color: #6b7280;
   margin-bottom: 1.5rem;
 }
 
@@ -65,6 +64,7 @@
   font-weight: 600;
   text-transform: capitalize;
   margin-bottom: 1rem;
+  text-align: center;
 }
 
 .weather-details {
@@ -91,7 +91,6 @@
 
 .detail-label {
   font-size: 0.875rem;
-  color: #6b7280;
 }
 
 .light-theme .detail-label {
@@ -111,23 +110,45 @@
   font-size: 1.25rem;
   font-weight: 600;
   text-align: center;
-  color: #6b7280;
 }
 
 .light-theme .message {
-  color: #6b7280;
+  color: #374151;
 }
 
 .dark-theme .message {
-  color: #9ca3af;
+  color: #d1d5db;
 }
 
 .message.error {
   color: #ef4444;
 }
 
+.details-link-wrapper {
+  margin-top: 1.75rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.details-link {
+  display: inline-block;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  background-color: var(--primary-button-bg);
+  color: #fff;
+}
+
+.details-link:hover {
+  background-color: var(--primary-button-hover-bg);
+  transform: translateY(-2px);
+}
+
 @media (max-width: 640px) {
-  .app-title {
-    font-size: 2rem;
+  .weather-details {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/components/WeatherDisplay.jsx
+++ b/src/components/WeatherDisplay.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './WeatherDisplay.css';
 
-const WeatherDisplay = ({ data, loading, error }) => {
+const WeatherDisplay = ({ data, loading, error, showDetailsLink = false }) => {
   if (loading) {
     return <div className="message">Cargando datos del clima...</div>;
   }
@@ -11,17 +12,23 @@ const WeatherDisplay = ({ data, loading, error }) => {
   }
 
   if (!data) {
-    return <div className="message">
-        Usa la barra de búsqueda para ver el clima de una ciudad.
-        </div>;
+    return <div className="message">Usa la barra de búsqueda para ver el clima de una ciudad.</div>;
   }
-  
+
   const iconUrl = `https://openweathermap.org/img/wn/${data.weather[0].icon}@2x.png`;
+  const forecastLink = `/forecast/${encodeURIComponent(data.name)}`;
 
   return (
     <div className="weather-display-card">
       <h2 className="city-name">{data.name}</h2>
-      <p className="date">{new Date().toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</p>
+      <p className="date">
+        {new Date().toLocaleDateString('es-ES', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })}
+      </p>
       <div className="main-weather">
         <img src={iconUrl} alt={data.weather[0].description} className="weather-icon" />
         <p className="temperature">{Math.round(data.main.temp)}°C</p>
@@ -45,6 +52,13 @@ const WeatherDisplay = ({ data, loading, error }) => {
           <p className="detail-value">{data.main.pressure} hPa</p>
         </div>
       </div>
+      {showDetailsLink && (
+        <div className="details-link-wrapper">
+          <Link className="details-link" to={forecastLink}>
+            Ver pronóstico detallado
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    document.body.classList.remove('light-theme', 'dark-theme');
+    document.body.classList.add(`${theme}-theme`);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme debe utilizarse dentro de un ThemeProvider');
+  }
+  return context;
+};

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+
+export const useFetch = (url) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!url) {
+      setData(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let isMounted = true;
+
+    const fetchData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok) {
+          let message = 'No se pudo obtener la información solicitada.';
+          try {
+            const errorData = await response.json();
+            if (errorData?.message) {
+              message = errorData.message;
+            }
+          } catch (jsonError) {
+            // Ignorar errores al parsear el JSON del error.
+          }
+
+          if (response.status === 404) {
+            message = 'No se encontraron datos del clima para esta ciudad. Por favor, revisa el nombre.';
+          }
+
+          throw new Error(message);
+        }
+        const json = await response.json();
+        if (isMounted) {
+          setData(json);
+        }
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (isMounted) {
+          setError(err.message);
+          setData(null);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [url]);
+
+  return { data, isLoading, error };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,13 @@
 :root {
   --font-family: 'Inter', sans-serif;
   --bg-color-light: linear-gradient(135deg, #60a5fa, #83c2fd);
-  --text-color-light: #2c3e50;
+  --text-color-light: #1f2937;
   --bg-card-light: rgba(255, 255, 255, 0.3);
   --shadow-light: 0 10px 15px rgba(0, 0, 0, 0.1);
-  --border-color-light: #ccc;
+  --border-color-light: #cbd5f5;
   --hover-color-light: rgba(255, 255, 255, 0.5);
 
-  --bg-color-dark: #1f2937;
+  --bg-color-dark: #0f172a;
   --text-color-dark: #f9fafb;
   --bg-card-dark: rgba(55, 65, 81, 0.6);
   --shadow-dark: 0 10px 15px rgba(0, 0, 0, 0.3);
@@ -19,6 +19,10 @@
 
   --primary-button-bg: #2563eb;
   --primary-button-hover-bg: #1e40af;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -33,7 +37,7 @@ body {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  padding: 1rem;
+  padding: 2rem 1rem 3rem;
   transition: background-color 0.5s ease, color 0.5s ease;
 }
 
@@ -47,26 +51,162 @@ body {
   color: var(--text-color-dark);
 }
 
-.app-content {
-  position: relative;
+.app-wrapper {
   width: 100%;
-  max-width: 640px;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+}
+
+.app-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.light-theme .nav-link {
+  color: var(--text-color-light);
+}
+
+.dark-theme .nav-link {
+  color: var(--text-color-dark);
+}
+
+.nav-link.active {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.dark-theme .nav-link.active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-content {
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 2rem;
 }
 
-.app-title {
+.page {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.app-title,
+.page-title {
   font-size: 2.5rem;
   font-weight: 800;
   text-align: center;
-  margin-bottom: 1.5rem;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+  margin: 0;
+}
+
+.page-subtitle {
+  font-size: 1.125rem;
+  text-align: center;
+  max-width: 48rem;
+  margin: 0;
+}
+
+.section {
+  width: 100%;
+  max-width: 48rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  text-align: center;
+}
+
+.feature-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.feature-list.ordered {
+  list-style: decimal;
+}
+
+.extended-details {
+  width: 100%;
+  max-width: 48rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.extended-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.extended-item {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dark-theme .extended-item {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.extended-label {
+  font-size: 0.875rem;
+  opacity: 0.85;
+}
+
+.extended-value {
+  font-size: 1.125rem;
+  font-weight: 600;
 }
 
 @media (max-width: 640px) {
-  .app-title {
+  .app-container {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .app-title,
+  .page-title {
     font-size: 2rem;
+  }
+
+  .page-subtitle {
+    font-size: 1rem;
   }
 }

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,0 +1,30 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import ThemeSwitcher from '../components/ThemeSwitcher.jsx';
+import { useTheme } from '../context/ThemeContext.jsx';
+
+const AppLayout = () => {
+  const { theme } = useTheme();
+
+  return (
+    <div className={`app-container ${theme}-theme`}>
+      <div className="app-wrapper">
+        <header className="app-header">
+          <nav className="navigation">
+            <NavLink to="/" end className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+              Inicio
+            </NavLink>
+            <NavLink to="/about" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+              Acerca de
+            </NavLink>
+          </nav>
+          <ThemeSwitcher />
+        </header>
+        <main className="app-content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './index.css';
+import App from './App.jsx';
+import { ThemeProvider } from './context/ThemeContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
-)
+);

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,29 @@
+const About = () => (
+  <div className="page about-page">
+    <h1 className="page-title">Acerca de la aplicación</h1>
+    <p className="page-subtitle">
+      Esta aplicación muestra información meteorológica actualizada utilizando la API de OpenWeatherMap
+      e incorpora un sistema de enrutamiento para ofrecer una experiencia de SPA completa.
+    </p>
+    <section className="section">
+      <h2 className="section-title">Características destacadas</h2>
+      <ul className="feature-list">
+        <li>Consulta del clima actual en diferentes ciudades del mundo.</li>
+        <li>Detalles adicionales del pronóstico, como temperaturas extremas, amanecer y atardecer.</li>
+        <li>Selector de tema claro/oscuro compartido por toda la aplicación.</li>
+        <li>Enrutamiento con división de código para cargar secciones bajo demanda.</li>
+      </ul>
+    </section>
+    <section className="section">
+      <h2 className="section-title">Cómo utilizarla</h2>
+      <ol className="feature-list ordered">
+        <li>Desde la página de inicio, busca una ciudad para ver su información principal.</li>
+        <li>Utiliza el enlace “Ver pronóstico detallado” para consultar más datos del mismo lugar.</li>
+        <li>Visita esta página para conocer la arquitectura y las funcionalidades principales.</li>
+        <li>Cambia de tema en cualquier momento usando el interruptor situado en la barra de navegación.</li>
+      </ol>
+    </section>
+  </div>
+);
+
+export default About;

--- a/src/pages/ForecastDetails.jsx
+++ b/src/pages/ForecastDetails.jsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import SearchBar from '../components/SearchBar.jsx';
+import WeatherDisplay from '../components/WeatherDisplay.jsx';
+import { useFetch } from '../hooks/useFetch.js';
+
+const formatTime = (timestamp) =>
+  new Date(timestamp * 1000).toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+const formatVisibility = (visibility) => {
+  if (visibility == null) {
+    return 'Sin datos';
+  }
+  return `${(visibility / 1000).toFixed(1)} km`;
+};
+
+const ForecastDetails = () => {
+  const { city } = useParams();
+  const navigate = useNavigate();
+
+  const decodedCity = useMemo(() => decodeURIComponent(city ?? ''), [city]);
+  const API_KEY = import.meta.env.VITE_API_KEY;
+  const url = decodedCity
+    ? `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(decodedCity)}&appid=${API_KEY}&units=metric&lang=es`
+    : null;
+
+  const { data, isLoading, error } = useFetch(url);
+
+  const handleSearch = (newCity) => {
+    if (newCity) {
+      navigate(`/forecast/${encodeURIComponent(newCity)}`);
+    }
+  };
+
+  const extendedDetails = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    return [
+      {
+        label: 'Temperatura mínima',
+        value: `${Math.round(data.main.temp_min)}°C`,
+      },
+      {
+        label: 'Temperatura máxima',
+        value: `${Math.round(data.main.temp_max)}°C`,
+      },
+      {
+        label: 'Amanecer',
+        value: formatTime(data.sys.sunrise),
+      },
+      {
+        label: 'Atardecer',
+        value: formatTime(data.sys.sunset),
+      },
+      {
+        label: 'Visibilidad',
+        value: formatVisibility(data.visibility),
+      },
+      {
+        label: 'Nubosidad',
+        value: `${data.clouds.all}%`,
+      },
+    ];
+  }, [data]);
+
+  return (
+    <div className="page forecast-page">
+      <h1 className="page-title">Pronóstico detallado</h1>
+      <p className="page-subtitle">Explora información adicional sobre las condiciones actuales en {decodedCity}.</p>
+      <SearchBar onSearch={handleSearch} />
+      <WeatherDisplay data={data} loading={isLoading} error={error} />
+      {data && (
+        <section className="extended-details" aria-label="Información adicional del clima">
+          <h2 className="section-title">Información adicional</h2>
+          <div className="extended-grid">
+            {extendedDetails.map(detail => (
+              <div className="extended-item" key={detail.label}>
+                <span className="extended-label">{detail.label}</span>
+                <span className="extended-value">{detail.value}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default ForecastDetails;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import SearchBar from '../components/SearchBar.jsx';
+import WeatherDisplay from '../components/WeatherDisplay.jsx';
+import { useFetch } from '../hooks/useFetch.js';
+
+const Home = () => {
+  const [selectedCity, setSelectedCity] = useState('');
+
+  const handleSearch = (city) => {
+    setSelectedCity(city);
+  };
+
+  const API_KEY = import.meta.env.VITE_API_KEY;
+  const url = selectedCity
+    ? `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(selectedCity)}&appid=${API_KEY}&units=metric&lang=es`
+    : null;
+
+  const { data, isLoading, error } = useFetch(url);
+
+  return (
+    <div className="page home-page">
+      <h1 className="app-title">Panel de Control del Clima</h1>
+      <p className="page-subtitle">Busca el clima actual de cualquier ciudad y consulta detalles adicionales.</p>
+      <SearchBar onSearch={handleSearch} />
+      <WeatherDisplay data={data} loading={isLoading} error={error} showDetailsLink />
+    </div>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- add React Router with a shared layout, home search, forecast details, and lazily-loaded about page
- move the theme toggle into a global ThemeContext and update the navigation switcher
- introduce a reusable useFetch hook and refactor weather pages to use it while polishing UI copy and docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8bd00a68883309ddff4ddfd715de6